### PR TITLE
In readme file mistakes fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ APIs are implemented using Django Rest Framework.
 
 In order to use the APIs do the following steps: <br>
     - Clone the repository: <br> ```git clone <repository link> ``` <br>
-    - Intsall dependencies: <br> ```git install -r requirements.txt ``` <br>
+    - Intsall dependencies: <br> ```pip install -r requirements.txt ``` <br>
+    - Run migration command to create database: <br> ```python.exe manage.py migrate ``` <br>
     - Run the project: <br> ```python.exe manage.py runserver ``` <br>
     - API documentation of the project can be found at : localhost:api/schema/docs
 


### PR DESCRIPTION
## Before running server we must migrate 

##and it is not `git install` it must be `pip install`